### PR TITLE
Removed trailing commas that were causing theme to break.

### DIFF
--- a/Numix Dark.sublime-theme
+++ b/Numix Dark.sublime-theme
@@ -471,7 +471,7 @@
     {
         "class": "tree_row",
         "layer0.tint": [49,49,49],
-        "layer0.opacity": 1,
+        "layer0.opacity": 1
     },
     // Sidebar row selected
     {

--- a/Numix.sublime-theme
+++ b/Numix.sublime-theme
@@ -471,7 +471,7 @@
     {
         "class": "tree_row",
         "layer0.tint": [212,212,212],
-        "layer0.opacity": 1,
+        "layer0.opacity": 1
     },
     // Sidebar row selected
     {


### PR DESCRIPTION
This was found to be a problem on a fresh install of Sublime Text 2 with this theme installed via Package Control. Setting `"theme": "Numix.sublime-theme"` in user settings cause the Sublime theme to break. Removing the trailing commas fixed the issue.